### PR TITLE
Add support for `invoice_reference` in tests

### DIFF
--- a/tests/test_hostfact_python_client.py
+++ b/tests/test_hostfact_python_client.py
@@ -118,6 +118,7 @@ def test_make_invoice_http_request(client):
 
     result = client.invoice.make_invoice(**{
         "debtor_code": "DB100",
+        "invoice_reference": "PO123456",
         "invoice_lines": [
             {
                 "Description": "test@test.nl",
@@ -131,20 +132,20 @@ def test_make_invoice_http_request(client):
         }
     })
 
-    assert (result == {'Identifier': '9300'})
+    assert (result == {'Identifier': '25683'})
 
     invoice = client.invoice.show(Identifier=result['Identifier'])['invoice']
 
     assert (invoice["Attachments"] == [
         {
-        "Identifier": "49",
+        "Identifier": "17715",
         "Filename": "test.txt"
         }
     ])
     assert (invoice["InvoiceLines"] == [
         {
-        "Identifier": 318661,
-        "Date": "2021-06-18",
+        "Identifier": 351157,
+        "Date": "2025-09-17",
         "Number": "1",
         "NumberSuffix": "",
         "ProductCode": "",
@@ -170,6 +171,7 @@ def test_make_invoice_http_request(client):
 
     result = client.invoice.make_invoice(**{
         "debtor_code": "DB100",
+        "invoice_reference": "PO654321",
         "invoice_lines": [
             {
                 "Description": "Big money",
@@ -182,14 +184,14 @@ def test_make_invoice_http_request(client):
 
     assert (invoice["Attachments"] == [
         {
-        "Identifier": "49",
+        "Identifier": "17715",
         "Filename": "test.txt"
         }
     ])
     assert (invoice["InvoiceLines"] == [
         {
-            "Identifier": 318661,
-            "Date": "2021-06-18",
+            "Identifier": 351157,
+            "Date": "2025-09-17",
             "Number": "1",
             "NumberSuffix": "",
             "ProductCode": "",
@@ -211,8 +213,8 @@ def test_make_invoice_http_request(client):
             "DiscountAmountExcl": 0
         },
         {
-            "Identifier": 318662,
-            "Date": "2021-06-18",
+            "Identifier": 351158,
+            "Date": "2025-09-17",
             "Number": "1",
             "NumberSuffix": "",
             "ProductCode": "",

--- a/tests/vcr_cassettes/invoice.make_invoice.yaml
+++ b/tests/vcr_cassettes/invoice.make_invoice.yaml
@@ -1,167 +1,129 @@
 interactions:
 - request:
-    body: api_key=secret&controller=invoice&action=add&DebtorCode=DB100&InvoiceLines%5B0%5D%5BDescription%5D=test%40test.nl&InvoiceLines%5B0%5D%5BPriceExcl%5D=2222
+    body: api_key=secret&controller=invoice&action=add&DebtorCode=DB100&ReferenceNumber=PO123456&InvoiceLines%5B0%5D%5BDescription%5D=test%40test.nl&InvoiceLines%5B0%5D%5BPriceExcl%5D=2222
     headers:
-      Content-Type:
+      content-type:
       - application/x-www-form-urlencoded
-      Host:
+      host:
       - your-hostfact-server.com
     method: POST
     uri: https://your-hostfact-server.com/Pro/apiv2/api.php
   response:
-    content: '{"controller":"invoice","action":"add","status":"success","date":"2021-06-18T14:46:53+02:00","invoice":{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2021-06-18","Term":"0","PayBefore":"2021-06-18","PaymentURL":"","AmountExcl":"2222.00","AmountTax":"466.62","AmountIncl":"2688.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"info@db100.nl","InvoiceMethod":"0","Template":"38","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":318661,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2021-06-18
-        14:46:53","Modified":"2021-06-18 14:46:53","Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
-        e-mail","Template":"NL - Default Invoice","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":2222,"AmountTax":466.62,"AmountIncl":2688.62}}}}'
-    body:
-      string: '{"controller":"invoice","action":"add","status":"success","date":"2021-06-18T14:46:53+02:00","invoice":{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2021-06-18","Term":"0","PayBefore":"2021-06-18","PaymentURL":"","AmountExcl":"2222.00","AmountTax":"466.62","AmountIncl":"2688.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"info@db100.nl","InvoiceMethod":"0","Template":"38","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":318661,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2021-06-18
-        14:46:53","Modified":"2021-06-18 14:46:53","Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
-        e-mail","Template":"NL - Default Invoice","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":2222,"AmountTax":466.62,"AmountIncl":2688.62}}}}'
+    content: '{"controller":"invoice","action":"add","status":"success","date":"2025-09-17T14:55:46+02:00","invoice":{"Identifier":"25683","InvoiceCode":"[concept]0001","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2025-09-17","Term":"0","PayBefore":"2025-09-17","PaymentURL":"","AmountExcl":"2222.00","AmountTax":"466.62","AmountIncl":"2688.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","TaxableSetting":"auto","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"PO123456","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"DB100@nextpertise.nl","InvoiceMethod":"0","Template":"39","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":351157,"Date":"2025-09-17","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2025-09-17
+      14:55:46","Modified":"2025-09-17 14:55:46","Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
+      e-mail","Template":"NL - Nextpertise Factuur 0% BTW","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":2222,"AmountTax":466.62,"AmountIncl":2688.62}}}}'
     headers:
       Content-Type:
       - application/json
     http_version: HTTP/1.1
     status_code: 200
-    status:
-      code: 200
-      message: OK
 - request:
-    body: api_key=secret&controller=attachment&action=add&InvoiceCode=%5Bconcept%5D0012&Type=invoice&Filename=test.txt&Base64=b%27SGVsbG8gd29ybGQ%3D%27
+    body: api_key=secret&controller=attachment&action=add&InvoiceCode=%5Bconcept%5D0001&Type=invoice&Filename=test.txt&Base64=b%27SGVsbG8gd29ybGQ%3D%27
     headers:
-      Content-Type:
+      content-type:
       - application/x-www-form-urlencoded
-      Host:
+      host:
       - your-hostfact-server.com
-      User-Agent:
-      - Python-urllib/3.8
     method: POST
     uri: https://your-hostfact-server.com/Pro/apiv2/api.php
   response:
-    content:
-      '{"controller":"attachment","action":"add","status":"success","date":"2021-06-18T14:46:54+02:00","success":["Het
-              bestand ''test.txt'' is toegevoegd als bijlage bij de factuur"]}'
-    body:
-      string: '{"controller":"attachment","action":"add","status":"success","date":"2021-06-18T14:46:54+02:00","success":["Het
-        bestand ''test.txt'' is toegevoegd als bijlage bij de factuur"]}'
+    content: '{"controller":"attachment","action":"add","status":"success","date":"2025-09-17T14:55:47+02:00","success":["Het
+      bestand ''test.txt'' is toegevoegd als bijlage bij de factuur"]}'
     headers:
       Content-Type:
       - application/json
     http_version: HTTP/1.1
     status_code: 200
-    status:
-      code: 200
-      message: OK
 - request:
-    body: api_key=secret&controller=invoice&action=show&Identifier=9300
+    body: api_key=secret&controller=invoice&action=show&Identifier=25683
     headers:
-      Content-Type:
+      content-type:
       - application/x-www-form-urlencoded
-      Host:
+      host:
       - your-hostfact-server.com
-      User-Agent:
-      - Python-urllib/3.8
     method: POST
     uri: https://your-hostfact-server.com/Pro/apiv2/api.php
   response:
-    content: '{"controller":"invoice","action":"show","status":"success","date":"2021-06-18T14:46:55+02:00","invoice":{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2021-06-18","Term":"0","PayBefore":"2021-06-18","PaymentURL":"","AmountExcl":"2222.00","AmountTax":"466.62","AmountIncl":"2688.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"info@db100.nl","InvoiceMethod":"0","Template":"38","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":318661,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2021-06-18
-        14:46:53","Modified":"2021-06-18 14:46:53","Attachments":[{"Identifier":"49","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
-        e-mail","Template":"NL - Default Invoice","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":2222,"AmountTax":466.62,"AmountIncl":2688.62}}}}'
-    body:
-      string: '{"controller":"invoice","action":"show","status":"success","date":"2021-06-18T14:46:55+02:00","invoice":{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2021-06-18","Term":"0","PayBefore":"2021-06-18","PaymentURL":"","AmountExcl":"2222.00","AmountTax":"466.62","AmountIncl":"2688.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"info@db100.nl","InvoiceMethod":"0","Template":"38","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":318661,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2021-06-18
-        14:46:53","Modified":"2021-06-18 14:46:53","Attachments":[{"Identifier":"49","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
-        e-mail","Template":"NL - Default Invoice","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":2222,"AmountTax":466.62,"AmountIncl":2688.62}}}}'
+    content: '{"controller":"invoice","action":"show","status":"success","date":"2025-09-17T14:55:47+02:00","invoice":{"Identifier":"25683","InvoiceCode":"[concept]0001","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2025-09-17","Term":"0","PayBefore":"2025-09-17","PaymentURL":"","AmountExcl":"2222.00","AmountTax":"466.62","AmountIncl":"2688.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","TaxableSetting":"auto","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"PO123456","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"DB100@nextpertise.nl","InvoiceMethod":"0","Template":"39","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":351157,"Date":"2025-09-17","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2025-09-17
+      14:55:46","Modified":"2025-09-17 14:55:46","Attachments":[{"Identifier":"17715","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
+      e-mail","Template":"NL - Nextpertise Factuur 0% BTW","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":2222,"AmountTax":466.62,"AmountIncl":2688.62}}}}'
     headers:
       Content-Type:
       - application/json
     http_version: HTTP/1.1
     status_code: 200
-    status:
-      code: 200
-      message: OK
 - request:
-    body: api_key=secret&controller=invoice&action=list&DebtorCode=DB100&Status=0&sort=Modified
+    body: api_key=secret&controller=invoice&action=list&searchat=DebtorCode&searchfor=DB100&status=0&sort=Modified
     headers:
-      Content-Type:
+      content-type:
       - application/x-www-form-urlencoded
-      Host:
+      host:
       - your-hostfact-server.com
-      User-Agent:
-      - Python-urllib/3.8
     method: POST
     uri: https://your-hostfact-server.com/Pro/apiv2/api.php
   response:
-    content: '{"controller":"invoice","action":"list","status":"success","date":"2021-06-18T14:46:56+02:00","totalresults":12,"currentresults":12,"offset":0,"filters":{"sort":"Modified"},"invoices":[{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","CompanyName":"DB100","Initials":"D.","SurName":"Code","AmountExcl":"2222.00","AmountIncl":"2688.62","AmountOpen":0,"Date":"2021-06-18","Status":"0","SubStatus":"","Authorisation":"no","Modified":"2021-06-18
-        14:46:53"},{"Identifier":"9289","InvoiceCode":"[concept]0001","Debtor":"1","DebtorCode":"DB100","CompanyName":"DB100","Initials":"D.","SurName":"Code","AmountExcl":"165.00","AmountIncl":"199.65","AmountOpen":0,"Date":"2021-06-17","Status":"0","SubStatus":"","Authorisation":"no","Modified":"2021-06-17
-        12:25:46"}]}'
-    body:
-      string: '{"controller":"invoice","action":"list","status":"success","date":"2021-06-18T14:46:56+02:00","totalresults":12,"currentresults":12,"offset":0,"filters":{"sort":"Modified"},"invoices":[{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","CompanyName":"DB100","Initials":"D.","SurName":"Code","AmountExcl":"2222.00","AmountIncl":"2688.62","AmountOpen":0,"Date":"2021-06-18","Status":"0","SubStatus":"","Authorisation":"no","Modified":"2021-06-18
-        14:46:53"},{"Identifier":"9289","InvoiceCode":"[concept]0001","Debtor":"1","DebtorCode":"DB100","CompanyName":"DB100","Initials":"D.","SurName":"Code","AmountExcl":"165.00","AmountIncl":"199.65","AmountOpen":0,"Date":"2021-06-17","Status":"0","SubStatus":"","Authorisation":"no","Modified":"2021-06-17
-        12:25:46"}]}'
+    content: '{"controller":"invoice","action":"list","status":"success","date":"2025-09-17T14:55:47+02:00","totalresults":1,"currentresults":1,"offset":0,"filters":{"sort":"Modified","searchat":"DebtorCode","searchfor":"DB100","status":"0"},"invoices":[{"Identifier":"25683","InvoiceCode":"[concept]0001","Debtor":"1","DebtorCode":"DB100","CompanyName":"DB100","Initials":"D.","SurName":"Code","AmountExcl":"2222.00","AmountIncl":"2688.62","AmountOpen":0,"Date":"2025-09-17","Status":"0","SubStatus":"","Authorisation":"no","Modified":"2025-09-17
+      14:55:46"}]}'
     headers:
       Content-Type:
       - application/json
     http_version: HTTP/1.1
     status_code: 200
-    status:
-      code: 200
-      message: OK
 - request:
-    body: api_key=secret&controller=invoiceline&action=add&Identifier=9300&InvoiceLines%5B0%5D%5BDescription%5D=Big+money&InvoiceLines%5B0%5D%5BPriceExcl%5D=5000
+    body: api_key=secret&controller=invoice&action=edit&Identifier=25683&ReferenceNumber=PO654321
     headers:
-      Content-Type:
+      content-type:
       - application/x-www-form-urlencoded
-      Host:
+      host:
       - your-hostfact-server.com
-      User-Agent:
-      - Python-urllib/3.8
     method: POST
     uri: https://your-hostfact-server.com/Pro/apiv2/api.php
   response:
-    content: '{"controller":"invoiceline","action":"add","status":"success","date":"2021-06-18T14:46:57+02:00","success":["Er
-        zijn 1 factuurregels toegevoegd"],"invoice":{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2021-06-18","Term":"0","PayBefore":"2021-06-18","PaymentURL":"","AmountExcl":"7222.00","AmountTax":"1516.62","AmountIncl":"8738.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"info@db100.nl","InvoiceMethod":"0","Template":"38","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":318661,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0},{"Identifier":318662,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"Big
-        money","PriceExcl":"5000","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":6050,"NoDiscountAmountExcl":5000,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2021-06-18
-        14:46:53","Modified":"2021-06-18 14:46:57","Attachments":[{"Identifier":"49","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
-        e-mail","Template":"NL - Default Invoice","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":7222,"AmountTax":1516.62,"AmountIncl":8738.62}}}}'
-    body:
-      string: '{"controller":"invoiceline","action":"add","status":"success","date":"2021-06-18T14:46:57+02:00","success":["Er
-        zijn 1 factuurregels toegevoegd"],"invoice":{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2021-06-18","Term":"0","PayBefore":"2021-06-18","PaymentURL":"","AmountExcl":"7222.00","AmountTax":"1516.62","AmountIncl":"8738.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"info@db100.nl","InvoiceMethod":"0","Template":"38","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":318661,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0},{"Identifier":318662,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"Big
-        money","PriceExcl":"5000","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":6050,"NoDiscountAmountExcl":5000,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2021-06-18
-        14:46:53","Modified":"2021-06-18 14:46:57","Attachments":[{"Identifier":"49","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
-        e-mail","Template":"NL - Default Invoice","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":7222,"AmountTax":1516.62,"AmountIncl":8738.62}}}}'
+    content: '{"controller":"invoice","action":"edit","status":"success","date":"2025-09-17T14:55:47+02:00","invoice":{"Identifier":"25683","InvoiceCode":"[concept]0001","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2025-09-17","Term":"0","PayBefore":"2025-09-17","PaymentURL":"","AmountExcl":"2222.00","AmountTax":"466.62","AmountIncl":"2688.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","TaxableSetting":"auto","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"PO654321","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"DB100@nextpertise.nl","InvoiceMethod":"0","Template":"39","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":351157,"Date":"2025-09-17","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2025-09-17
+      14:55:46","Modified":"2025-09-17 14:55:47","Attachments":[{"Identifier":"17715","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
+      e-mail","Template":"NL - Nextpertise Factuur 0% BTW","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":2222,"AmountTax":466.62,"AmountIncl":2688.62}}}}'
     headers:
       Content-Type:
       - application/json
     http_version: HTTP/1.1
     status_code: 200
-    status:
-      code: 200
-      message: OK
 - request:
-    body: api_key=secret&controller=invoice&action=show&Identifier=9300
+    body: api_key=secret&controller=invoiceline&action=add&Identifier=25683&InvoiceLines%5B0%5D%5BDescription%5D=Big+money&InvoiceLines%5B0%5D%5BPriceExcl%5D=5000
     headers:
-      Content-Type:
+      content-type:
       - application/x-www-form-urlencoded
-      Host:
+      host:
       - your-hostfact-server.com
-      User-Agent:
-      - Python-urllib/3.8
     method: POST
     uri: https://your-hostfact-server.com/Pro/apiv2/api.php
   response:
-    content: '{"controller":"invoice","action":"show","status":"success","date":"2021-06-18T14:46:57+02:00","invoice":{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2021-06-18","Term":"0","PayBefore":"2021-06-18","PaymentURL":"","AmountExcl":"7222.00","AmountTax":"1516.62","AmountIncl":"8738.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"info@db100.nl","InvoiceMethod":"0","Template":"38","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":318661,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0},{"Identifier":318662,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"Big
-        money","PriceExcl":"5000","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":6050,"NoDiscountAmountExcl":5000,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2021-06-18
-        14:46:53","Modified":"2021-06-18 14:46:57","Attachments":[{"Identifier":"49","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
-        e-mail","Template":"NL - Default Invoice","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":7222,"AmountTax":1516.62,"AmountIncl":8738.62}}}}'
-    body:
-      string: '{"controller":"invoice","action":"show","status":"success","date":"2021-06-18T14:46:57+02:00","invoice":{"Identifier":"9300","InvoiceCode":"[concept]0012","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2021-06-18","Term":"0","PayBefore":"2021-06-18","PaymentURL":"","AmountExcl":"7222.00","AmountTax":"1516.62","AmountIncl":"8738.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"info@db100.nl","InvoiceMethod":"0","Template":"38","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":318661,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0},{"Identifier":318662,"Date":"2021-06-18","Number":"1","NumberSuffix":"","ProductCode":"","Description":"Big
-        money","PriceExcl":"5000","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":6050,"NoDiscountAmountExcl":5000,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2021-06-18
-        14:46:53","Modified":"2021-06-18 14:46:57","Attachments":[{"Identifier":"49","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
-        e-mail","Template":"NL - Default Invoice","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":7222,"AmountTax":1516.62,"AmountIncl":8738.62}}}}'
+    content: '{"controller":"invoiceline","action":"add","status":"success","date":"2025-09-17T14:55:47+02:00","success":["Er
+      zijn 1 factuurregels toegevoegd"],"invoice":{"Identifier":"25683","InvoiceCode":"[concept]0001","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2025-09-17","Term":"0","PayBefore":"2025-09-17","PaymentURL":"","AmountExcl":"7222.00","AmountTax":"1516.62","AmountIncl":"8738.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","TaxableSetting":"auto","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"PO654321","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"DB100@nextpertise.nl","InvoiceMethod":"0","Template":"39","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":351157,"Date":"2025-09-17","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0},{"Identifier":351158,"Date":"2025-09-17","Number":"1","NumberSuffix":"","ProductCode":"","Description":"Big
+      money","PriceExcl":"5000","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":6050,"NoDiscountAmountExcl":5000,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2025-09-17
+      14:55:46","Modified":"2025-09-17 14:55:47","Attachments":[{"Identifier":"17715","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
+      e-mail","Template":"NL - Nextpertise Factuur 0% BTW","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":7222,"AmountTax":1516.62,"AmountIncl":8738.62}}}}'
     headers:
       Content-Type:
       - application/json
     http_version: HTTP/1.1
     status_code: 200
-    status:
-      code: 200
-      message: OK
+- request:
+    body: api_key=secret&controller=invoice&action=show&Identifier=25683
+    headers:
+      content-type:
+      - application/x-www-form-urlencoded
+      host:
+      - your-hostfact-server.com
+    method: POST
+    uri: https://your-hostfact-server.com/Pro/apiv2/api.php
+  response:
+    content: '{"controller":"invoice","action":"show","status":"success","date":"2025-09-17T14:55:48+02:00","invoice":{"Identifier":"25683","InvoiceCode":"[concept]0001","Debtor":"1","DebtorCode":"DB100","Status":"0","SubStatus":"","Date":"2025-09-17","Term":"0","PayBefore":"2025-09-17","PaymentURL":"","AmountExcl":"7222.00","AmountTax":"1516.62","AmountIncl":"8738.62","TaxRate":0,"Compound":"no","AmountPaid":"0.00","Discount":0,"VatCalcMethod":"excl","TaxableSetting":"auto","IgnoreDiscount":"no","Coupon":"","ReferenceNumber":"PO654321","CompanyName":"DB100","TaxNumber":"","Sex":"m","Initials":"D.","SurName":"Code","Address":"Address","ZipCode":"1000AA","City":"Amsterdam","Country":"NL","EmailAddress":"DB100@nextpertise.nl","InvoiceMethod":"0","Template":"39","ScheduledAt":"","SentDate":"","Sent":"0","Reminders":"0","ReminderDate":"","Summations":"0","SummationDate":"","Authorisation":"no","PaymentMethod":"","PayDate":"","TransactionID":"","Description":"","Comment":"","InvoiceLines":[{"Identifier":351157,"Date":"2025-09-17","Number":"1","NumberSuffix":"","ProductCode":"","Description":"test@test.nl","PriceExcl":"2222","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":2688.62,"NoDiscountAmountExcl":2222,"DiscountAmountIncl":0,"DiscountAmountExcl":0},{"Identifier":351158,"Date":"2025-09-17","Number":"1","NumberSuffix":"","ProductCode":"","Description":"Big
+      money","PriceExcl":"5000","DiscountPercentage":0,"DiscountPercentageType":"line","TaxPercentage":21,"PeriodicID":"0","Periods":"1","Periodic":"","StartPeriod":"","EndPeriod":"","ProductType":"","Reference":"0","NoDiscountAmountIncl":6050,"NoDiscountAmountExcl":5000,"DiscountAmountIncl":0,"DiscountAmountExcl":0}],"Created":"2025-09-17
+      14:55:46","Modified":"2025-09-17 14:55:47","Attachments":[{"Identifier":"17715","Filename":"test.txt"}],"Translations":{"Status":"Concept","Country":"Nederland","InvoiceMethod":"Per
+      e-mail","Template":"NL - Nextpertise Factuur 0% BTW","PaymentMethod":""},"AmountDiscount":0,"AmountDiscountIncl":0,"UsedTaxrates":{"0.21":{"AmountExcl":7222,"AmountTax":1516.62,"AmountIncl":8738.62}}}}'
+    headers:
+      Content-Type:
+      - application/json
+    http_version: HTTP/1.1
+    status_code: 200
 version: 1


### PR DESCRIPTION
This pull request includes the following changes:
- Updates to the `make_invoice` test cases to include support for the `invoice_reference` property.
- Modifications to related test fixtures to align with the changes.